### PR TITLE
[FEATURE] Log Account Which Performed Activity

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,10 +26,11 @@ COLUMN_REASON = 6      # G
 COLUMN_RETURN_TIME = 7 # H
 COLUMN_PHONE = 8       # I
 COLUMN_AFFILIATION = 9 # J
+COLUMN_ACCOUNT = 10    # K
 
-COLUMN_HEADERS_ARRAY = ["Date", "Time", "Name", "Action", "User Type", "Grade", "Reason", "Return Time", "Visitor Phone", "Visitor Affiliation"]
+COLUMN_HEADERS_ARRAY = ["Date", "Time", "Name", "Action", "User Type", "Grade", "Reason", "Return Time", "Visitor Phone", "Visitor Affiliation", "Account"]
 
-COLUMNS_TOTAL = "9"
+COLUMNS_TOTAL = "10"
 
 # Define preset options for the "reason"
 SIGN_OUT_REASONS_STAFF      = ["Lunch", "Sick", "Appointment", "Meeting", "Field Trip"]

--- a/routes.py
+++ b/routes.py
@@ -47,6 +47,11 @@ def signinout():
 
 @main_bp.route('/submit', methods=['POST'])
 def submit():
+    auth = request.authorization
+    account = "unknown"
+    if auth:
+        account = auth.username
+
     action = request.form['action']
     name = request.form['name']
     user_type = request.form['user_type']
@@ -87,11 +92,12 @@ def submit():
         COLUMN_HEADERS_ARRAY[7]: return_time,
         COLUMN_HEADERS_ARRAY[8]: visitor_phone,
         COLUMN_HEADERS_ARRAY[9]: visitor_affiliation,
+        COLUMN_HEADERS_ARRAY[10]: account
     }
 
     # Create or get the sheet and append the row
     worksheet = get_or_create_sheet(sheet_name)
-    worksheet.append_row([current_date, current_time_formatted, name, action, user_type, grade, reason, return_time, visitor_phone, visitor_affiliation])
+    worksheet.append_row([current_date, current_time_formatted, name, action, user_type, grade, reason, return_time, visitor_phone, visitor_affiliation, account])
 
     # Save a local copy of data to XLSX doc
     save_to_local_file(entry)


### PR DESCRIPTION
## Changes
- Pulls authenticated "user"/"account" name when submitting activity.
- Adds column to data spreadsheets for "account"

## Use Case
This is designed so each iPad can be signed in as a different account allowing tracking of entry/exit point.

## Notes
- The terms user and account can be ambiguous, because the user the app is signed in as, does not reflect the actual user, but instead is more of session identifier. Thus, the term account is preferred as it provides less confusion.
- **User**: The person using the app (i.e. entering a sign in/out action).
- **Account**: The authenticated session on the device.
- **User Account**: The name given to an account that can authenticate a session.