### PR TITLE
[CONFIG] Temp Remove Sign-out Reason for Staff

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -27,9 +27,12 @@ function handleAction(action, userType, reasonNeeded) {
     if (userType === "Student" && action === "Signing Out") {
         reasonField.style.display = "block";
         actionButtons.style.display = "none";  // Hide the action buttons
-    } else if (userType === "Staff" && action === "Signing Out" && reasonNeeded === "true") {
-        reasonField.style.display = "block";
-        actionButtons.style.display = "none";  // Hide the action buttons
+// NOTE: This is commented out to make a last minute change to just prevent staff from being asked a reason when signing out.
+// I'll need to look at fixing this so either the timing system works better or just add a seperate option for end of day,
+// Or better yet, just keep this change perminent and don't ask for signout reason.
+    // } else if (userType === "Staff" && action === "Signing Out" && reasonNeeded === "true") {
+    //     reasonField.style.display = "block";
+    //     actionButtons.style.display = "none";  // Hide the action buttons
     } else if (userType === "Visitor" && action === "Signing In") {
         visitorReasonField.style.display = "block";
         actionButtons.style.display = "none";  // Hide the Sign In/Out buttons


### PR DESCRIPTION
While figuring out a better solution, don't ask staff a reason when signing out. This issue came up because of timezones and python defaulting to UTC, original plan was for no reason to be asked after 2pm, but for now I'm going to set no reason ever and see how we get on.