### PR TITLE
[FIX] fix time zone issue with staff sign out reason

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,7 @@ COLUMN_HEADERS_ARRAY = ["Date", "Time", "Name", "Action", "User Type", "Grade", 
 COLUMNS_TOTAL = "11"
 
 # Define preset options for the "reason"
-SIGN_OUT_REASONS_STAFF      = ["Lunch", "Sick", "Appointment", "Meeting", "Field Trip"]
+SIGN_OUT_REASONS_STAFF      = ["Lunch", "Sick", "Appointment", "Meeting", "Field Trip", "Going Home"]
 SIGN_OUT_REASONS_STUDENT    = ["Lunch", "Sick", "Appointment"]
 # Remember to send parent contact to school for sick, or appointment
 

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -27,12 +27,9 @@ function handleAction(action, userType, reasonNeeded) {
     if (userType === "Student" && action === "Signing Out") {
         reasonField.style.display = "block";
         actionButtons.style.display = "none";  // Hide the action buttons
-// NOTE: This is commented out to make a last minute change to just prevent staff from being asked a reason when signing out.
-// I'll need to look at fixing this so either the timing system works better or just add a seperate option for end of day,
-// Or better yet, just keep this change perminent and don't ask for signout reason.
-    // } else if (userType === "Staff" && action === "Signing Out" && reasonNeeded === "true") {
-    //     reasonField.style.display = "block";
-    //     actionButtons.style.display = "none";  // Hide the action buttons
+    } else if (userType === "Staff" && action === "Signing Out" && reasonNeeded === "true") {
+        reasonField.style.display = "block";
+        actionButtons.style.display = "none";  // Hide the action buttons
     } else if (userType === "Visitor" && action === "Signing In") {
         visitorReasonField.style.display = "block";
         actionButtons.style.display = "none";  // Hide the Sign In/Out buttons

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,8 @@ import subprocess
 import os
 import csv
 
-from datetime import datetime
+from datetime import datetime, time
+import pytz
 from config import PERSONNEL_CSV_PATH
 
 def format_time(datetime_obj):
@@ -70,8 +71,10 @@ USERS = load_users_from_csv()
 
 # Helper for preventing reason when end of day sign out
 def should_ask_reason_and_return_time(user_type):
-    current_time = datetime.now().time()
-    cutoff_time = datetime.strptime("22:00", "%H:%M").time()  # 2 PM
-    if user_type == "Staff" and current_time > cutoff_time:
+    # Get the current time in Vancouver
+    vancouver_tz = pytz.timezone("America/Vancouver")
+    vancouver_time = datetime.now(vancouver_tz).time()
+    cutoff_time = time(14, 0)  # 2:00 PM Vancouver time
+    if user_type == "Staff" and vancouver_time > cutoff_time:
         return "false"  # Don't ask for reason/return time
     return "true"  # Ask for reason/return time


### PR DESCRIPTION
Adds back sign out reason for staff, but only until 2pm on weekdays. Fixes the time zone issues that were occurring.