### PR TITLE
[FIX] Add more rows to table when new sheet created

### DIFF
--- a/sheets.py
+++ b/sheets.py
@@ -15,7 +15,7 @@ def get_or_create_sheet(sheet_name):
     try:
         worksheet = spreadsheet.worksheet(sheet_name)
     except gspread.exceptions.WorksheetNotFound:
-        worksheet = spreadsheet.add_worksheet(title=sheet_name, rows="100", cols=COLUMNS_TOTAL)
+        worksheet = spreadsheet.add_worksheet(title=sheet_name, rows="500", cols=COLUMNS_TOTAL)
         worksheet.append_row(COLUMN_HEADERS_ARRAY)  # Add headers
 
         # Bold the header row and freeze it


### PR DESCRIPTION
Prevent issue where table created for the days logs only has 100 rows. This issue makes sorting difficult, as the sheet will only sort rows in the table and not those out side the table. This fix is a bit janky as it just increases the table size to 500, but there should never be a case where that many rows are hit.

Long-term: Transitioning to proper SQL DB store will solve weird issues like this properly.